### PR TITLE
Add DataFrame validation and tests

### DIFF
--- a/DataPreValidation.py
+++ b/DataPreValidation.py
@@ -1,0 +1,52 @@
+import pandas as Pandas
+from typing import List, Tuple
+
+
+def ValidateInputDataframe(
+    InputTable: Pandas.DataFrame,
+) -> Tuple[bool, List[str]]:
+    """Validate that the input table meets schema and content requirements."""
+    Errors: List[str] = []
+
+    if not isinstance(InputTable, Pandas.DataFrame):
+        Errors.append("InputTable must be a pandas DataFrame.")
+        return False, Errors
+
+    RowCount = InputTable.shape[0]
+    if RowCount == 0:
+        Errors.append("InputTable is empty.")
+    if RowCount > 1_000_000:
+        Errors.append("InputTable exceeds maximum row count of 1,000,000.")
+
+    RequiredColumns = {"StaffId", "TalentStatement"}
+    MissingColumns = RequiredColumns - set(InputTable.columns)
+    for Column in MissingColumns:
+        Errors.append(f"Missing required column: {Column}")
+
+    if not MissingColumns:
+        StaffIdSeries = InputTable["StaffId"]
+        TalentStatementSeries = InputTable["TalentStatement"]
+
+        if StaffIdSeries.isna().any() or not StaffIdSeries.map(
+            lambda Value: isinstance(Value, str)
+        ).all():
+            Errors.append("Column StaffId must contain strings without nulls.")
+
+        if TalentStatementSeries.isna().any() or not TalentStatementSeries.map(
+            lambda Value: isinstance(Value, str)
+        ).all():
+            Errors.append(
+                "Column TalentStatement must contain strings without nulls."
+            )
+        else:
+            InvalidRows = TalentStatementSeries[
+                TalentStatementSeries.apply(lambda Value: Value.strip() == "")
+            ].index.tolist()
+            if InvalidRows:
+                Errors.append(
+                    "TalentStatement contains empty or whitespace values at "
+                    f"rows: {InvalidRows}"
+                )
+
+    IsValid = len(Errors) == 0
+    return IsValid, Errors

--- a/Main.py
+++ b/Main.py
@@ -1,0 +1,21 @@
+import pandas as Pandas
+from DataPreValidation import ValidateInputDataframe
+
+
+def Main() -> None:
+    InputTable = Pandas.DataFrame(
+        [
+            {
+                "StaffId": "S001",
+                "TalentStatement": "I want to move into data engineering.",
+            },
+            {"StaffId": "S002", "TalentStatement": "Happy in current role."},
+        ]
+    )
+    IsValid, Errors = ValidateInputDataframe(InputTable)
+    print(f"IsValid: {IsValid}")
+    print(f"Errors: {Errors}")
+
+
+if __name__ == "__main__":
+    Main()

--- a/UnitTests/DataPreValidationTests.py
+++ b/UnitTests/DataPreValidationTests.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import unittest
+import pandas as Pandas
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from DataPreValidation import ValidateInputDataframe  # noqa: E402
+
+
+class DataPreValidationTests(unittest.TestCase):
+    def TestValidInputDataframe(self) -> None:
+        InputTable = Pandas.DataFrame(
+            [
+                {
+                    "StaffId": "S001",
+                    "TalentStatement": (
+                        "I want to move into data engineering."
+                    ),
+                },
+                {
+                    "StaffId": "S002",
+                    "TalentStatement": "Happy in current role.",
+                },
+            ]
+        )
+        IsValid, Errors = ValidateInputDataframe(InputTable)
+        self.assertTrue(IsValid)
+        self.assertEqual(Errors, [])
+
+    def TestMissingRequiredColumn(self) -> None:
+        InputTable = Pandas.DataFrame([{"StaffId": "S001"}])
+        IsValid, Errors = ValidateInputDataframe(InputTable)
+        self.assertFalse(IsValid)
+        self.assertIn("Missing required column: TalentStatement", Errors)
+
+    def TestEmptyTalentStatement(self) -> None:
+        InputTable = Pandas.DataFrame(
+            [{"StaffId": "S001", "TalentStatement": "   "}]
+        )
+        IsValid, Errors = ValidateInputDataframe(InputTable)
+        self.assertFalse(IsValid)
+        self.assertTrue(
+            any(
+                "TalentStatement contains empty or whitespace" in Error
+                for Error in Errors
+            )
+        )
+
+    def TestRowLimitExceeded(self) -> None:
+        InputTable = Pandas.DataFrame(
+            {
+                "StaffId": ["S001"] * 1_000_001,
+                "TalentStatement": ["Valid"] * 1_000_001,
+            }
+        )
+        IsValid, Errors = ValidateInputDataframe(InputTable)
+        self.assertFalse(IsValid)
+        self.assertIn(
+            "InputTable exceeds maximum row count of 1,000,000.",
+            Errors,
+        )
+
+    def TestStaffIdNotString(self) -> None:
+        InputTable = Pandas.DataFrame(
+            [{"StaffId": 123, "TalentStatement": "Valid"}]
+        )
+        IsValid, Errors = ValidateInputDataframe(InputTable)
+        self.assertFalse(IsValid)
+        self.assertIn(
+            "Column StaffId must contain strings without nulls.",
+            Errors,
+        )
+
+
+def LoadTests() -> unittest.TestSuite:
+    Suite = unittest.TestSuite()
+    Suite.addTest(DataPreValidationTests("TestValidInputDataframe"))
+    Suite.addTest(DataPreValidationTests("TestMissingRequiredColumn"))
+    Suite.addTest(DataPreValidationTests("TestEmptyTalentStatement"))
+    Suite.addTest(DataPreValidationTests("TestRowLimitExceeded"))
+    Suite.addTest(DataPreValidationTests("TestStaffIdNotString"))
+    return Suite
+
+
+if __name__ == "__main__":
+    Runner = unittest.TextTestRunner()
+    Runner.run(LoadTests())


### PR DESCRIPTION
## Summary
- add ValidateInputDataframe to enforce schema, data types and row limits
- wire example usage in Main
- cover success and failure paths with unit tests